### PR TITLE
feat: Display Upcoming Games from API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,12 +12,14 @@ interface GameDetails {
   cover: string;
   title: string;
   genre: string;
+  releaseDate?: string;
 }
 function App() {
   // Get the auth type the user selected
   const [selectedAuth, setSelectedAuth] = useState<string>("login");
   const [session, setSession] = useState<Session | null>(null);
   const [popularGames, setPopularGames] = useState<GameDetails[]>([]);
+  const [upcomingGames, setUpcomingGames] = useState<GameDetails[]>([]);
 
   useEffect(() => {
     // Check if the user is logged in
@@ -49,7 +51,15 @@ function App() {
       }).catch((error) => console.error(error));
     }
 
+    const getUpcomingGames = async () => {
+      axios.post("https://nextplay-48g3.onrender.com/api/upcomingGames"
+      ).then((response) => {
+        setUpcomingGames(response.data);
+      }).catch((error) => console.error(error));
+    };
+
     getTopGames();
+    getUpcomingGames();
   }, []);
 
   return (
@@ -63,6 +73,7 @@ function App() {
       ) : null}
       <div className="popularGames">
         <h2>Popular Games</h2>
+        {popularGames.length === 0 ? <p>Loading...</p> : (
         <div className="gameCardContainer">
           {popularGames.map((game, index) => (
             <GameCard
@@ -74,15 +85,24 @@ function App() {
             />
           ))}
         </div>
+        )}
       </div>
       <div className="upcomingGames">
         <h2>Upcoming Games</h2>
-        <GameCard
-          cover="https://placehold.jp/50x50.png"
-          title="The Elder Scrolls VI"
-          genre="Role-playing (RPG)"
-          btnType="Upcoming"
-        />
+        {upcomingGames.length === 0 ? <p>Loading...</p> : (
+        <div className="gameCardContainer">
+          {upcomingGames.map((game, index) => (
+            <GameCard
+              key={index}
+              cover={game.cover}
+              title={game.title}
+              genre={game.genre}
+              releaseDate={game.releaseDate}
+              btnType="Upcoming"
+            />
+          ))}
+        </div>
+        )}
       </div>
     </>
   );

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -5,12 +5,14 @@ interface GameCardProps {
   cover: string;
   title: string;
   genre: string;
+  releaseDate?: string;
   btnType: string;
 }
 const GameCard: React.FC<GameCardProps> = ({
   cover,
   title,
   genre,
+  releaseDate,
   btnType,
 }) => {
   return (
@@ -18,7 +20,8 @@ const GameCard: React.FC<GameCardProps> = ({
       <img className="gameCover" src={cover} alt={title} />
       <div className="gameCardBody">
         <h3>{title}</h3>
-          <p>{genre}</p>
+        <p>{genre}</p>
+        <p>{releaseDate}</p>
       {btnType === "Upcoming" ? (
         <button className="notifyBtn">
           <Notification wd="1.25rem" ht="1.25rem" color="var(--background-light)"/> Notify Me

--- a/server/controllers/apiController.js
+++ b/server/controllers/apiController.js
@@ -23,14 +23,14 @@ const topSteamGamesByPlayerCount = async (req, res) => {
         "external_popularity_source",
       ])
       .sort("value", "desc")
-      .limit(6)
+      .limit(5)
       .where(["external_popularity_source = 1"])
       .where(["popularity_type = 5"])
       .request("/popularity_primitives");
 
     // Get the cover and title for each game using the game_id in a multiquery
       const gamevalues =  response.data.map(async (game) => {
-        return await getTitleCoverMQ(game.game_id);
+        return await getGameInfoMQ(game.game_id);
       });
 
     // Await for all the returned promises to resolve before returning to the frontend
@@ -58,7 +58,7 @@ const getGenre = async (genreId) => {
 
 // Multi Query to get the cover and title for a game based on the game id
 // Returns a promise that resolves to an object with the cover, title and genre of the game
-const getTitleCoverMQ = async (gameId)=> {
+const getGameInfoMQ = async (gameId)=> {
     const gameInfo = {};
   try {
     const response = await apicalypse(requestOptions).multi([
@@ -69,16 +69,26 @@ const getTitleCoverMQ = async (gameId)=> {
         .where(`game = ${gameId}`),
         // Get the title
         apicalypse()
-        .query("games", "title")
+        .query("games", "gameData")
         .fields([
             "name",
-            "genres"
+            "genres",
+            "first_release_date"
           ])
-        .where(`id = ${gameId}`)
+        .where(`id = ${gameId}`),
+        // Convert release date to a human readable string
+        apicalypse()
+        .query("release_dates", "releaseDate")
+        .fields([
+            "game",
+            "human"
+          ])
+        .where(`game = ${gameId}`)
     ]).request("multiquery");
     gameInfo.title = response.data[1].result[0].name;
     gameInfo.cover = `https://images.igdb.com/igdb/image/upload/t_cover_big/${response.data[0].result[0].image_id}.jpg`;
-
+    gameInfo.releaseDate = response.data[2].result[0].human;
+    
     // Get the genre based on the genre id returned from the multiquery
     gameInfo.genre = await getGenre(response.data[1].result[0].genres[0]);
     return gameInfo;
@@ -87,4 +97,36 @@ const getTitleCoverMQ = async (gameId)=> {
   }
 };
 
-export { topSteamGamesByPlayerCount };
+const upcomingGames = async (req, res) => {
+  try {
+    // Get the date for today, tomorrow and 3 months from now
+    const today = Math.floor(Date.now() / 1000);
+    const tomorrow = today + 86400;
+    const threeMonthsLater = today + (86400 * 90);
+
+    // Get the top 5 upcoming games based on release date between tomorrow and 3 months from now;
+    const response = await apicalypse(requestOptions)
+      .fields([
+        "id",
+        "first_release_date",
+      ])
+      .sort("first_release_date", "asc")
+      .where(`first_release_date > ${tomorrow} & first_release_date < ${threeMonthsLater} & themes != ${42}`)
+      .limit(5)
+      .request("/games");
+
+       // Get the game info for each game using the game_id in the multiquery
+       const gamevalues =  response.data.map(async (game) => {
+        return await getGameInfoMQ(game.id);
+      });
+
+    // Await for all the returned promises to resolve before returning to the frontend
+    const upcomingGames = await Promise.all(gamevalues);
+    return res.status(200).json(upcomingGames);
+  } catch (error) {
+    return res.status(500).json({ error: error });
+  }
+
+};
+
+export { topSteamGamesByPlayerCount, upcomingGames };

--- a/server/routes/apiRoutes.js
+++ b/server/routes/apiRoutes.js
@@ -1,7 +1,9 @@
 import express from "express";
 const router = express.Router();
-import { topSteamGamesByPlayerCount } from "../controllers/apiController.js";
+import { topSteamGamesByPlayerCount, upcomingGames } from "../controllers/apiController.js";
 
 router.post("/topSteamGamesByPlayerCount", topSteamGamesByPlayerCount);
+
+router.post("/upcomingGames", upcomingGames);
 
 export default router;


### PR DESCRIPTION
Implement Upcoming Games API Route.
This route will allow users to the site to see what new games are releasing soon.
The games display have a release date between the next day when the site is accessed up until 3 months. 